### PR TITLE
patch for breaking change at webpack-merge@5.0.0

### DIFF
--- a/templates/webpack/dev.js
+++ b/templates/webpack/dev.js
@@ -3,7 +3,7 @@ export function getWebpackDevConfig({ rules, plugins }) {
 		const fs = require('fs');
 		const path = require('path');
 		const webpack = require('webpack');
-		const merge = require('webpack-merge');
+		const { merge } = require('webpack-merge');
 		const commonConfig = require('./webpack.common.js');
 		const HtmlWebpackPlugin = require('html-webpack-plugin');
 

--- a/templates/webpack/prod.js
+++ b/templates/webpack/prod.js
@@ -3,7 +3,7 @@ export function getWebpackProdConfig({ rules, plugins }) {
 		const fs = require('fs');
 		const path = require('path');
 		const webpack = require('webpack');
-		const merge = require('webpack-merge');
+		const { merge } = require('webpack-merge');
 		const commonConfig = require('./webpack.common.js');
 		const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 		const TerserWebpackPlugin = require('terser-webpack-plugin');


### PR DESCRIPTION
Webpack changed how they exported the merge function in 5.0.0.

Relevant StackOverflow post: https://stackoverflow.com/a/62851985/8835688
